### PR TITLE
Add support for large SVGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Primarily maintained by Toke Eskildsen, [toes@kb.dk](mailto:toes@kb.dk), Royal D
 
 ## Requirements
 
-* bash, wget, GraphicsMagic, vips (only tested under Ubuntu)
+* bash, xmllint, wget, GraphicsMagic, vips (only tested under Ubuntu)
 * SVG exported from Gephi
 
 

--- a/generate_presentation.sh
+++ b/generate_presentation.sh
@@ -600,7 +600,7 @@ elif [[ "false" == "$VIPS_ONLY" ]]; then
     if [[ "false" == "$RENDER_TILES" ]]; then
         echo "- Skipping rendering of PNG as RENDER_PNG=${RENDER_PNG} and RENDER_TILES=${RENDER_TILES}"
     else 
-        echo "- RENDER_PNG=${RENDER_PNG} specified, but with VIPS_ONLY=${VIPS_ONLY}, a PNG is required and will thus be rendered anywat"
+        echo "- RENDER_PNG=${RENDER_PNG} specified, but with VIPS_ONLY=${VIPS_ONLY}, a PNG is required and will thus be rendered anyway"
         create_png
     fi
 else

--- a/svg_render.sh
+++ b/svg_render.sh
@@ -103,7 +103,7 @@ extract_part() {
     echo "   - Extracting $PART"
     normalise_svg | grep -A 999999999 "<g id=\"$PART\">" | grep -B 999999999 '</g>' -m 1 | grep -v '</\?g' > "${T}/${PART}.xml"
     if [[ ! -s "${T}/${PART}.xml" ]]; then
-        >&2 echo "Error: No $PART extracted from $SVG"
+        >&2 echo "Warning: No $PART extracted from ${SVG}. Suspicious but not fatal"
     fi
     split -l $SVG_MAX_LINES -a 4 "${T}/${PART}.xml" "${T}/${PART}-part.xml_"
 }
@@ -153,9 +153,11 @@ batch_render() {
     local LINES=$(normalise_svg | grep '<' | wc -l)
     echo " - Splitting SVG with $LINES lines in parts of max $SVG_MAX_LINES lines"
     echo "   - Extracting header"
-    normalise_svg | sed 's/<style\/>/<style><\/style>/' | grep -B 999999999 '</style>' > "${T}/header.xml"
+    normalise_svg | grep -B 999999 -m 1 '<g ' | head -n -1 > "${T}/header.xml"
+#    normalise_svg | sed 's/<style\/>/<style><\/style>/' | grep -B 999999999 '</style>' > "${T}/header.xml"
     if [[ ! -s "${T}/header.xml" ]]; then
         >&2 echo "Error: No header extracted from $SVG"
+        exit 10
     fi
 
     for PART in $PARTS; do


### PR DESCRIPTION
`librsvg`, which is used for rendering SVGs, has a limit on the number of nodes in an SVG:
 * https://gitlab.gnome.org/GNOME/librsvg/-/issues/574
 * https://gitlab.gnome.org/GNOME/librsvg/-/blob/main/src/limits.rs

This pull request adds support for multi-pass rendering of SVGs, effectively removing that limitation (at the cost of speed).

And yes, I accidentally added `svg_render.sh` to the `master` branch. Sorry.